### PR TITLE
Point directly at the feed for http://blog.andrew-jones.com

### DIFF
--- a/perlsphere.yaml
+++ b/perlsphere.yaml
@@ -128,7 +128,7 @@ plugins:
           title: Moose Blog
         - url:   http://feeds.feedburner.com/plu
           title: Johannes Plunien
-        - url:   http://blog.andrew-jones.com/tag/perl/
+        - url:   http://blog.andrew-jones.com/tag/perl/feed/
           title: Andrew Jones
         - url:   http://wp.colliertech.org/cj/?cat=18
           title: The Paedantic Programmer


### PR DESCRIPTION
Currently plagger is looking at the HTML page for http://blog.andrew-jones.com/tags/perl and parsing it to find the RSS feed. It looks like its taking the first feed found, which is actually the feed for my whole blog, not just the perl tag.

It's not easy to get Wordpress to change the order of the RSS feeds on the page to put the correct one first, so by pointing plagger directly at the feed, it should just get my perl specific posts.

Thanks.
