### PR TITLE
Relative width (scales with zooming in and out) for main column

### DIFF
--- a/themes/common/base-weblog.css
+++ b/themes/common/base-weblog.css
@@ -71,7 +71,7 @@ body { text-align: center; } /* center on ie */
 {
 	position: relative;
 	margin: 0 auto; /* center on everything else */
-	width: 720px;
+	width: 50em;
 	text-align: left;
 }
 #container-inner { position: static; width: auto; }


### PR DESCRIPTION
Hi, this fixes the problem I mentioned where the Perlsphere layout isn't zoomable for reading on hi-res displays.
