### PR TITLE
Moved my blog up the config file to see if that helps with the problem where Plagger generates a bad link for my site.

### DIFF
--- a/perlsphere.yaml
+++ b/perlsphere.yaml
@@ -48,6 +48,8 @@ plugins:
           title: Ranguard's blog
         - url:   http://blogs.perl.org/users/peter_sergeant/
           title: Peter Sergeant
+        - url:   http://ericjohnson.posterous.com/rss.xml?tag=perl
+          title: Eric Johnson
         - url:   http://blog.phoenixtrap.com/feeds/posts/default/-/Perl
         - url:   http://blog.woobling.org/feeds/posts/default
         - url:   http://nxadm.wordpress.com/tag/perl/feed/
@@ -134,8 +136,6 @@ plugins:
           title: The Paedantic Programmer
         - url:   http://blogs.perl.org/users/mike_friedman/atom.xml
           title: Mike Friedman
-        - url:   http://ericjohnson.posterous.com/rss.xml?tag=perl
-          title: Eric Johnson
         - url:   http://blogs.perl.org/users/joel_berger/atom.xml
           title: Joel Berger
         - url:   http://blog.kraih.com/rss.xml


### PR DESCRIPTION
Just wildly guessing.  

FYI I don't have this problem on my box when I do a fresh install of Plagger.  XML::Feed has had several largish changes recently.  XML::Feed is the library which parses the RSS feeds and I'm guessing some bug was fixed in there and that perlsphere is using old libraries.  
